### PR TITLE
chore(package.json, __tests__): tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ To build, run `yarn llink` followed by `yarn build-storybook:<theme>` where them
 - gov
 
 To test build locally, run `npx http-server ./storybook-static` after building.
+
+## Test
+
+To run unit tests in all packages, run `yarn test:jest`

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "llink": "lerna link",
     "build": "lerna run build",
     "clean": "lerna clean",
+    "test:jest": "lerna run test:jest --stream",
     "storybook:base": "start-storybook -p 6006 -c .storybook/base",
     "storybook:gov": "start-storybook -p 6006 -c .storybook/gov",
     "deploy-storybook": "storybook-to-ghpages --packages packages --branch=storybook",

--- a/packages/component-library-gov/__tests__/Button.jest.tsx
+++ b/packages/component-library-gov/__tests__/Button.jest.tsx
@@ -1,0 +1,29 @@
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { render } from '@testing-library/react';
+import React from 'react';
+import Button from '../src/Button';
+import 'regenerator-runtime/runtime';
+
+expect.extend(toHaveNoViolations);
+
+describe('Button', () => {
+  it('Should have no accessibility violations', async () => {
+    const { container } = render(<Button>Button</Button>);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Should re-use css classes', () => {
+    const { getByText } = render(
+      <>
+        <Button primary>Button 1</Button>
+        <Button primary>Button 2</Button>
+      </>
+    );
+
+    const buttonOneClasses = getByText('Button 1').className;
+    const buttonTwoClasses = getByText('Button 2').className;
+    expect(buttonOneClasses).toEqual(buttonTwoClasses);
+  });
+});

--- a/packages/component-library-gov/package.json
+++ b/packages/component-library-gov/package.json
@@ -11,7 +11,8 @@
     "build": "node ../../scripts/build.js --name=component-library-gov",
     "build-docs": "yarn --cwd www build",
     "build-types": "yarn tsc -d --emitDeclarationOnly --outDir types",
-    "storybook": "start-storybook -p 6006"
+    "storybook": "start-storybook -p 6006",
+    "test:jest": "yarn jest"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.2",

--- a/packages/component-library/package.json
+++ b/packages/component-library/package.json
@@ -11,7 +11,8 @@
     "build": "node ../../scripts/build.js --name=component-library",
     "build-docs": "yarn --cwd www build",
     "build-types": "yarn tsc -d --emitDeclarationOnly --outDir types",
-    "storybook": "start-storybook -p 6006"
+    "storybook": "start-storybook -p 6006",
+    "test:jest": "yarn jest"
   },
   "dependencies": {
     "@babel/runtime": "^7.4.2",


### PR DESCRIPTION
Add tests to component-library-gov, command to run all tests from root

The test file is repetitive, but since the packages may break out at some point I figured we should keep separate tests for each package