### PR TITLE
chore(package.json): rename toolkit to be more descriptive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "pangolin",
+  "name": "service-development-toolkit",
   "version": "1.1.1",
   "description": "Toolkit for button applications",
   "main": "index.js",
-  "repository": "git@github.com:thebuttonclan/pangolin.git",
+  "repository": "git@github.com:button-inc/service-development-toolkit.git",
   "author": "Button Inc.",
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
Fixes #

## Proposed Changes

- rename pangolin to service-development toolkit
- updates in package.json to reflect this
