### PR TITLE
test(bcgov-theme/filepicker): update filepicker

### DIFF
--- a/packages/bcgov-theme/__tests__/FilePicker.test.tsx
+++ b/packages/bcgov-theme/__tests__/FilePicker.test.tsx
@@ -1,9 +1,11 @@
 import { axe, toHaveNoViolations } from 'jest-axe';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
 import FilePicker from '../src/FilePicker';
+import { styles } from '../src/Button';
 import '@testing-library/jest-dom/extend-expect';
 import 'regenerator-runtime/runtime';
+import { changeSelectorToObject } from '../utils/test-helpers';
 
 expect.extend(toHaveNoViolations);
 
@@ -13,5 +15,28 @@ describe('FilePicker', () => {
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
+  });
+
+  it('Should apply styles from props', () => {
+    const { getByText } = render(
+      <FilePicker rounded id="test">
+        Choose File
+      </FilePicker>
+    );
+    const dropdown = getByText('Choose File');
+    const stylesObject = changeSelectorToObject(styles.variant.primary.button);
+    expect(dropdown).toHaveStyle(stylesObject.base);
+  });
+
+  it('Should pass through end-user props', () => {
+    const handleClick = jest.fn();
+    const handleChange = jest.fn();
+    render(<FilePicker onClick={handleClick} onChange={handleChange} id="test" />);
+    const filepicker = document.getElementById('test');
+    fireEvent.click(filepicker);
+    fireEvent.change(filepicker, { target: { value: '' } });
+
+    expect(handleClick).toHaveBeenCalled();
+    expect(handleChange).toHaveBeenCalled();
   });
 });

--- a/packages/bcgov-theme/src/FilePicker.tsx
+++ b/packages/bcgov-theme/src/FilePicker.tsx
@@ -28,15 +28,6 @@ export const styles = {
       `,
     },
   },
-  required: {
-    label: `
-      &:after {
-        margin: -0.2em 0em 0em 0.2em;
-        content: '*';
-        color: #DB2828;
-      }
-    `,
-  },
 };
 
 const config: StyleConfig = {

--- a/packages/bcgov-theme/src/fontawesome.tsx
+++ b/packages/bcgov-theme/src/fontawesome.tsx
@@ -46,6 +46,7 @@ export const FaSVG = styled.svg.attrs({
   title: 'fa icon',
   xmlns: 'http://www.w3.org/2000/svg',
   viewBox: '0 0 512 512',
+  width: '15px', // Default inline style for when stylesheets don't come through. Prevents svg blowing up
 })`
   display: inline-block;
   font-size: inherit;

--- a/packages/bcgov-theme/stories/FilePicker.stories.tsx
+++ b/packages/bcgov-theme/stories/FilePicker.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
-import { HtmlOnlyWrapper, HtmlWithCssWrapper, Divider } from '../../../stories/helpers';
 import FilePicker from '../src/FilePicker';
 import BCGovTypography from './BCGovTypography';
 
@@ -15,33 +14,78 @@ export default {
       },
     },
   },
+  parameters: {
+    details: {
+      title: 'File Picker',
+      description: 'The file picker allows users to select a file to upload.',
+      allEnabledDescription: `The filepicker can be used to upload a single file. This component does not yet support showing file names, or
+      removing files. With javascript enabled, custom handlers (onChange) can be used to extend this.`,
+      cssEnabledDescription: `For users with CSS but not javascript, avoid putting important functionality in custom
+      handlers.`,
+      htmlOnlyDescription: `In an html only state, the default file input will show beside a non-functional button. This result can be improved,
+      but still gives users a path to uploading a file in an html only state.`,
+      usageCode: `
+        import FilePicker from '@button-inc/bcgov-theme/FilePicker';
+
+        export default function Component() {
+          return (
+            <div>
+              <FilePicker label="Upload a File" size="medium">Choose File</FilePicker>
+            </div>
+          )
+        }
+        `,
+      props: [
+        {
+          name: 'label',
+          type: 'string',
+          description: `The label for the input. If an id is not passed, one will be created to connect the label to the input.`,
+        },
+        {
+          name: 'size',
+          type: 'string',
+          description: `The size to use. Use one of ['small', 'medium', 'large'].`,
+        },
+        {
+          name: 'disabled',
+          type: 'boolean',
+          description: `Indicates whether the field is disabled.`,
+        },
+        {
+          name: 'required',
+          type: 'boolean',
+          description: `Indicates whether the field is required.`,
+        },
+        {
+          name: 'name',
+          type: 'string',
+          description: `The name to pass on to the input. If not provided, one will be generated with the suffix "-datepicker".`,
+        },
+        {
+          name: 'id',
+          type: 'string',
+          description: `The id to pass on to the input. If not provided but a label is given, one will be generated to connect them.`,
+        },
+        {
+          name: 'fullWidth',
+          type: 'boolean',
+          description: `Take up 100% of the width of the parent element.`,
+        },
+      ],
+    },
+  },
 } as Meta;
 
 const Template: Story = args => (
   <>
     <BCGovTypography />
-    <h3>HTML Only</h3>
-    <HtmlOnlyWrapper>
-      <FilePicker {...args}>Choose File</FilePicker>
-    </HtmlOnlyWrapper>
-
-    <Divider />
-
-    <h3>HTML + CSS</h3>
-    <HtmlWithCssWrapper>
-      <FilePicker {...args}>Choose File</FilePicker>
-    </HtmlWithCssWrapper>
-
-    <Divider />
-
-    <h3>HTML + CSS + JS</h3>
     <FilePicker {...args}>Choose File</FilePicker>
   </>
 );
 
 export const Default = Template.bind({});
 Default.args = {
-  label: 'Upload a file',
+  label: 'Upload a File',
   size: 'medium',
   required: false,
   disabled: false,


### PR DESCRIPTION
Default svg inline styles to keep them smaller in html only state. Add storybook story for the
filepicker, and extend unit tests for the bcgov design

Fixes #211

## Proposed Changes

- Update the storybook
- Add an inline style to svg's for when css works on the browser but stylesheets don't load. Will still blowup if css is fully disabled.
- Extend unit tests
- Remove required style, no longer recommended by the bcgov design guide
