### PR TITLE
Move 'page' demo out of components and into Getting Started docs

### DIFF
--- a/packages/bcgov-theme/stories/1_introduction-pages/5_Toolkit_in_Action/_Page.stories.mdx
+++ b/packages/bcgov-theme/stories/1_introduction-pages/5_Toolkit_in_Action/_Page.stories.mdx
@@ -1,0 +1,12 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import * as stories from './_Page.stories.tsx';
+
+<Meta title="Getting Started/Toolkit in Action" />
+
+# Toolkit in Action
+
+Here's an example of how the components in this toolkit can come together to make a service.
+
+<Canvas>
+  <Story story={stories.Default} name="Demo" />
+</Canvas>

--- a/packages/bcgov-theme/stories/1_introduction-pages/5_Toolkit_in_Action/_Page.stories.tsx
+++ b/packages/bcgov-theme/stories/1_introduction-pages/5_Toolkit_in_Action/_Page.stories.tsx
@@ -1,22 +1,22 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react/types-6-0';
-import Navigation from '../src/Navigation';
-import Footer from '../src/Footer';
-import Alert from '../src/Alert';
-import Input from '../src/Input';
-import DatePicker from '../src/DatePicker';
-import FilePicker from '../src/FilePicker';
-import Checkbox from '../src/Checkbox';
-import RadioButton from '../src/RadioButton';
-import Button from '../src/Button';
-import Callout from '../src/Callout';
-import Dropdown from '../src/Dropdown';
-import Textarea from '../src/Textarea';
-import Link from '../src/Link';
-import BCGovTypography from './BCGovTypography';
+import Navigation from '../../../src/Navigation';
+import Footer from '../../../src/Footer';
+import Alert from '../../../src/Alert';
+import Input from '../../../src/Input';
+import DatePicker from '../../../src/DatePicker';
+import FilePicker from '../../../src/FilePicker';
+import Checkbox from '../../../src/Checkbox';
+import RadioButton from '../../../src/RadioButton';
+import Button from '../../../src/Button';
+import Callout from '../../../src/Callout';
+import Dropdown from '../../../src/Dropdown';
+import Textarea from '../../../src/Textarea';
+import Link from '../../../src/Link';
+import BCGovTypography from '../../BCGovTypography';
 
 export default {
-  title: 'Components/_Page',
+  title: 'Getting Started/Toolkit in Action',
   argTypes: {
     size: {
       control: {


### PR DESCRIPTION
Fixes #290 

## Proposed Changes

- Moves `_Page` story out of component docs and into Getting Started section as Toolkit in Action page

<img width="1440" alt="Screen Shot 2021-07-02 at 12 25 00 PM" src="https://user-images.githubusercontent.com/5522075/124320342-9040a180-db30-11eb-87a1-55f212803036.png">
