### PR TITLE
feat: support for getRoute typeof function

### DIFF
--- a/packages/form-schema/src/interfaces.ts
+++ b/packages/form-schema/src/interfaces.ts
@@ -38,7 +38,7 @@ export interface IOptions {
   onPost?: Function;
   onFormEnd?: Function;
   useSession?: boolean;
-  getRoute: string;
+  getRoute: string | Function;
   postRoute: string;
   validatedUrl: string;
   invalidUrl: string;

--- a/packages/form-schema/src/utils/urlUtils.ts
+++ b/packages/form-schema/src/utils/urlUtils.ts
@@ -30,9 +30,11 @@ export const removeLeadingSlash = (url: string) => {
   return url;
 };
 
-export const parseUrl = (getRoute: string, nextPage: string) => {
+export const parseUrl = (getRoute: string | Function, nextPage: string, req?: any) => {
   let route;
-  if (getRoute[getRoute.length - 1] === '/') route = `${getRoute}${nextPage}`;
+  if (typeof getRoute === 'function') {
+    route = `${getRoute(req)}/${nextPage}`;
+  } else if (getRoute[getRoute.length - 1] === '/') route = `${getRoute}${nextPage}`;
   else route = `${getRoute}/${nextPage}`;
   return route;
 };

--- a/packages/form-schema/src/utils/validationUtils.ts
+++ b/packages/form-schema/src/utils/validationUtils.ts
@@ -72,7 +72,7 @@ export function redirectHandler(sharedArgs: ISharedArgs, js: boolean, postData: 
   if (js) {
     res.json(props);
   } else {
-    const redirectUrl = parseUrl(getRoute, String(nextPage));
+    const redirectUrl = parseUrl(getRoute, String(nextPage), req);
     res.redirect(redirectUrl);
   }
 }


### PR DESCRIPTION
## Proposed Changes

- getRoute option support for being type of function to return a route
- Including the request object in the getRoute function call
- Request param optional on the parseUrl function
- onPost requires request object
