### PR TITLE
chore: bump form-schema pkg pre-release patch version

### DIFF
--- a/examples/nextjs/demo/package.json
+++ b/examples/nextjs/demo/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@button-inc/bcgov-theme": "1.0.1",
     "@button-inc/component-library": "1.0.1",
-    "@button-inc/form-schema": "1.0.0-alpha.7",
+    "@button-inc/form-schema": "1.0.0-alpha.8",
     "next": "^10.2.3",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/examples/nextjs/form-schema-custom/package.json
+++ b/examples/nextjs/form-schema-custom/package.json
@@ -7,7 +7,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@button-inc/form-schema": "1.0.0-alpha.7",
+    "@button-inc/form-schema": "1.0.0-alpha.8",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/examples/nextjs/form-schema-default/package.json
+++ b/examples/nextjs/form-schema-default/package.json
@@ -7,7 +7,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@button-inc/form-schema": "1.0.0-alpha.7",
+    "@button-inc/form-schema": "1.0.0-alpha.8",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/packages/form-schema/package.json
+++ b/packages/form-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@button-inc/form-schema",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Build forms from a schema",
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
## Proposed Changes

- Bumps the alpha pre-release patch version of @button-inc/form-schema containing patch from [#374](https://github.com/button-inc/service-development-toolkit/pull/374) in prep to publish to npm