### PR TITLE
[form-schema] Make rjsf `description` prop available to components

### DIFF
--- a/packages/bcgov-theme/src/Checkbox.tsx
+++ b/packages/bcgov-theme/src/Checkbox.tsx
@@ -22,6 +22,10 @@ export const styles = {
         outline-offset: 1px;
       }
     `,
+    description: `
+      color: #606060;
+      font-size: 0.88em;
+    `,
     input: `
       position: absolute;
       opacity: 0;

--- a/packages/bcgov-theme/src/DatePicker.tsx
+++ b/packages/bcgov-theme/src/DatePicker.tsx
@@ -6,6 +6,11 @@ export const styles = {
       display: block;
       margin-bottom: 0.2777em;
     `,
+    description: `
+      margin-bottom: 0.2777em;
+      color: #606060;
+      font-size: 0.88em;
+    `,
     input: `
       display: block;
       border: 2px solid #606060;

--- a/packages/bcgov-theme/src/Dropdown.tsx
+++ b/packages/bcgov-theme/src/Dropdown.tsx
@@ -9,6 +9,11 @@ export const styles = {
       display: block;
       margin-bottom: 0.2777em;
     `,
+    description: `
+      margin-bottom: 0.2777em;
+      color: #606060;
+      font-size: 0.88em;
+    `,
     wrapper: `
       position: relative;
       display: flex;

--- a/packages/bcgov-theme/src/FilePicker.tsx
+++ b/packages/bcgov-theme/src/FilePicker.tsx
@@ -10,6 +10,11 @@ export const styles = {
       font-weight: 600;
       margin-bottom: 0.2777em;
     `,
+    description: `
+      margin-bottom: 0.2777em;
+      color: #606060;
+      font-size: 0.88em;
+    `,
   },
   size: {
     small: {

--- a/packages/bcgov-theme/src/Input.tsx
+++ b/packages/bcgov-theme/src/Input.tsx
@@ -6,6 +6,11 @@ export const styles = {
       display: block;
       margin-bottom: 0.2777em;
     `,
+    description: `
+      margin-bottom: 0.2777em;
+      color: #606060;
+      font-size: 0.88em;
+    `,
     input: `
       display: block;
       border: 2px solid #606060;

--- a/packages/bcgov-theme/src/RadioButton.tsx
+++ b/packages/bcgov-theme/src/RadioButton.tsx
@@ -20,6 +20,10 @@ export const styles = {
         outline-offset: 1px;
       }
     `,
+    description: `
+      color: #606060;
+      font-size: 0.88em;
+    `,
     input: `
       position: absolute;
       opacity: 0;

--- a/packages/bcgov-theme/src/Textarea.tsx
+++ b/packages/bcgov-theme/src/Textarea.tsx
@@ -6,6 +6,11 @@ export const styles = {
       display: block;
       margin-bottom: 0.2777em;
     `,
+    description: `
+      color: #606060;
+      font-size: 0.88em;
+      margin-bottom: 0.2777em;
+    `,
     input: `
       border: 2px solid #606060;
       border-radius: 0;

--- a/packages/bcgov-theme/stories/checkbox/args.ts
+++ b/packages/bcgov-theme/stories/checkbox/args.ts
@@ -13,9 +13,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   disabled: {
     description: 'Indicates whether the field is disabled.',

--- a/packages/bcgov-theme/stories/checkbox/args.ts
+++ b/packages/bcgov-theme/stories/checkbox/args.ts
@@ -11,6 +11,12 @@ export const argTypes = {
     description:
       'The label for the checkbox. If an id is not provided, one will be created to connect the label to the checkbox.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   disabled: {
     description: 'Indicates whether the field is disabled.',
   },

--- a/packages/bcgov-theme/stories/datepicker/args.ts
+++ b/packages/bcgov-theme/stories/datepicker/args.ts
@@ -12,9 +12,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   disabled: {
     description: 'Indicates whether the field is disabled.',

--- a/packages/bcgov-theme/stories/datepicker/args.ts
+++ b/packages/bcgov-theme/stories/datepicker/args.ts
@@ -10,6 +10,12 @@ export const argTypes = {
     description:
       'The label for the datepicker. If an id is not provided, one will be created to connect the label to the datepicker.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   disabled: {
     description: 'Indicates whether the field is disabled.',
   },

--- a/packages/bcgov-theme/stories/dropdown/args.ts
+++ b/packages/bcgov-theme/stories/dropdown/args.ts
@@ -12,9 +12,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   disabled: {
     description: 'Indicates whether the field is disabled.',

--- a/packages/bcgov-theme/stories/dropdown/args.ts
+++ b/packages/bcgov-theme/stories/dropdown/args.ts
@@ -10,6 +10,12 @@ export const argTypes = {
     description:
       'The label for the datepicker. If an id is not provided, one will be created to connect the label to the datepicker.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   disabled: {
     description: 'Indicates whether the field is disabled.',
   },

--- a/packages/bcgov-theme/stories/filepicker/args.ts
+++ b/packages/bcgov-theme/stories/filepicker/args.ts
@@ -18,9 +18,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   name: {
     description: 'The name to pass on to the input. If not provided, one will be generated.',

--- a/packages/bcgov-theme/stories/filepicker/args.ts
+++ b/packages/bcgov-theme/stories/filepicker/args.ts
@@ -16,6 +16,12 @@ export const argTypes = {
   label: {
     description: 'The label for the filepicker.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   name: {
     description: 'The name to pass on to the input. If not provided, one will be generated.',
   },

--- a/packages/bcgov-theme/stories/input/args.ts
+++ b/packages/bcgov-theme/stories/input/args.ts
@@ -18,9 +18,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   disabled: {
     description: 'Indicates whether the field is disabled.',

--- a/packages/bcgov-theme/stories/input/args.ts
+++ b/packages/bcgov-theme/stories/input/args.ts
@@ -16,6 +16,12 @@ export const argTypes = {
     description:
       'The label for the datepicker. If an id is not provided, one will be created to connect the label to the datepicker.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   disabled: {
     description: 'Indicates whether the field is disabled.',
   },

--- a/packages/bcgov-theme/stories/radio/args.ts
+++ b/packages/bcgov-theme/stories/radio/args.ts
@@ -12,9 +12,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   disabled: {
     description: 'Indicates whether the field is disabled.',

--- a/packages/bcgov-theme/stories/radio/args.ts
+++ b/packages/bcgov-theme/stories/radio/args.ts
@@ -10,6 +10,12 @@ export const argTypes = {
     description:
       'The label for the datepicker. If an id is not provided, one will be created to connect the label to the datepicker.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   disabled: {
     description: 'Indicates whether the field is disabled.',
   },

--- a/packages/bcgov-theme/stories/textarea/args.ts
+++ b/packages/bcgov-theme/stories/textarea/args.ts
@@ -10,6 +10,12 @@ export const argTypes = {
     description:
       'The label for the datepicker. If an id is not provided, one will be created to connect the label to the datepicker.',
   },
+  description: {
+    control: {
+      type: 'text'
+    },
+    description: "Optional description text that will be subordinate to the label if present."
+  },
   resize: {
     description: 'Whether to allow the textarea to be resized.',
     control: {

--- a/packages/bcgov-theme/stories/textarea/args.ts
+++ b/packages/bcgov-theme/stories/textarea/args.ts
@@ -12,9 +12,9 @@ export const argTypes = {
   },
   description: {
     control: {
-      type: 'text'
+      type: 'text',
     },
-    description: "Optional description text that will be subordinate to the label if present."
+    description: 'Optional description text that will be subordinate to the label if present.',
   },
   resize: {
     description: 'Whether to allow the textarea to be resized.',

--- a/packages/button-theme/src/Checkbox.tsx
+++ b/packages/button-theme/src/Checkbox.tsx
@@ -17,6 +17,7 @@ export const styles = {
       line-height: 1em;
       padding-left: 1.5em;
     `,
+    description: ``,
     input: `
       position: absolute;
       opacity: 0;

--- a/packages/button-theme/src/DatePicker.tsx
+++ b/packages/button-theme/src/DatePicker.tsx
@@ -7,6 +7,7 @@ export const styles = {
       font-weight: 600;
       margin-bottom: 0.277em;
     `,
+    description: ``,
     input: `
       margin: 0em;
       max-width: 100%;

--- a/packages/button-theme/src/Dropdown.tsx
+++ b/packages/button-theme/src/Dropdown.tsx
@@ -9,6 +9,7 @@ export const styles = {
       font-weight: 600;
       margin-bottom: 0.2777em;
     `,
+    description: ``,
     wrapper: `
       position: relative;
       display: flex;

--- a/packages/button-theme/src/FilePicker.tsx
+++ b/packages/button-theme/src/FilePicker.tsx
@@ -10,6 +10,7 @@ export const styles = {
       font-weight: 600;
       margin-bottom: 0.277em;
     `,
+    description: ``,
   },
   size: {
     small: {

--- a/packages/button-theme/src/Input.tsx
+++ b/packages/button-theme/src/Input.tsx
@@ -7,6 +7,7 @@ export const styles = {
       font-weight: 600;
       margin-bottom: 0.277em;
     `,
+    description: ``,
     input: `
       margin: 0em;
       max-width: 100%;

--- a/packages/button-theme/src/RadioButton.tsx
+++ b/packages/button-theme/src/RadioButton.tsx
@@ -15,6 +15,7 @@ export const styles = {
       line-height: 1em;
       padding-left: 1.5em;
     `,
+    description: ``,
     input: `
       position: absolute;
       opacity: 0;

--- a/packages/button-theme/src/Textarea.tsx
+++ b/packages/button-theme/src/Textarea.tsx
@@ -6,6 +6,7 @@ export const styles = {
       display: block;
       font-weight: 600;
     `,
+    description: ``,
     input: `
       margin: 0em;
       -webkit-appearance: none;

--- a/packages/button-theme/stories/Checkbox.stories.tsx
+++ b/packages/button-theme/stories/Checkbox.stories.tsx
@@ -15,6 +15,12 @@ export default {
         options: ['small', 'medium', 'large'],
       },
     },
+    description: {
+      control: {
+        type: 'text'
+      },
+      description: "Optional description text that will be subordinate to the label if present."
+    },
   },
 } as Meta;
 

--- a/packages/button-theme/stories/Checkbox.stories.tsx
+++ b/packages/button-theme/stories/Checkbox.stories.tsx
@@ -17,9 +17,9 @@ export default {
     },
     description: {
       control: {
-        type: 'text'
+        type: 'text',
       },
-      description: "Optional description text that will be subordinate to the label if present."
+      description: 'Optional description text that will be subordinate to the label if present.',
     },
   },
 } as Meta;

--- a/packages/button-theme/stories/DatePicker.stories.tsx
+++ b/packages/button-theme/stories/DatePicker.stories.tsx
@@ -14,6 +14,12 @@ export default {
         options: ['small', 'medium', 'large'],
       },
     },
+    description: {
+      control: {
+        type: 'text'
+      },
+      description: "Optional description text that will be subordinate to the label if present."
+    },
   },
 } as Meta;
 

--- a/packages/button-theme/stories/DatePicker.stories.tsx
+++ b/packages/button-theme/stories/DatePicker.stories.tsx
@@ -16,9 +16,9 @@ export default {
     },
     description: {
       control: {
-        type: 'text'
+        type: 'text',
       },
-      description: "Optional description text that will be subordinate to the label if present."
+      description: 'Optional description text that will be subordinate to the label if present.',
     },
   },
 } as Meta;

--- a/packages/button-theme/stories/Dropdown.stories.tsx
+++ b/packages/button-theme/stories/Dropdown.stories.tsx
@@ -14,6 +14,12 @@ export default {
         options: ['small', 'medium', 'large'],
       },
     },
+    description: {
+      control: {
+        type: 'text'
+      },
+      description: "Optional description text that will be subordinate to the label if present."
+    },
   },
 } as Meta;
 

--- a/packages/button-theme/stories/Dropdown.stories.tsx
+++ b/packages/button-theme/stories/Dropdown.stories.tsx
@@ -16,9 +16,9 @@ export default {
     },
     description: {
       control: {
-        type: 'text'
+        type: 'text',
       },
-      description: "Optional description text that will be subordinate to the label if present."
+      description: 'Optional description text that will be subordinate to the label if present.',
     },
   },
 } as Meta;

--- a/packages/button-theme/stories/FilePicker.stories.tsx
+++ b/packages/button-theme/stories/FilePicker.stories.tsx
@@ -14,6 +14,12 @@ export default {
         options: ['small', 'medium', 'large'],
       },
     },
+    description: {
+      control: {
+        type: 'text'
+      },
+      description: "Optional description text that will be subordinate to the label if present."
+    },
   },
 } as Meta;
 

--- a/packages/button-theme/stories/FilePicker.stories.tsx
+++ b/packages/button-theme/stories/FilePicker.stories.tsx
@@ -16,9 +16,9 @@ export default {
     },
     description: {
       control: {
-        type: 'text'
+        type: 'text',
       },
-      description: "Optional description text that will be subordinate to the label if present."
+      description: 'Optional description text that will be subordinate to the label if present.',
     },
   },
 } as Meta;

--- a/packages/button-theme/stories/Input.stories.tsx
+++ b/packages/button-theme/stories/Input.stories.tsx
@@ -14,6 +14,12 @@ export default {
         options: ['small', 'medium', 'large'],
       },
     },
+    description: {
+      control: {
+        type: 'text'
+      },
+      description: "Optional description text that will be subordinate to the label if present."
+    },
   },
 } as Meta;
 

--- a/packages/button-theme/stories/Input.stories.tsx
+++ b/packages/button-theme/stories/Input.stories.tsx
@@ -16,9 +16,9 @@ export default {
     },
     description: {
       control: {
-        type: 'text'
+        type: 'text',
       },
-      description: "Optional description text that will be subordinate to the label if present."
+      description: 'Optional description text that will be subordinate to the label if present.',
     },
   },
 } as Meta;

--- a/packages/button-theme/stories/RadioButton.stories.tsx
+++ b/packages/button-theme/stories/RadioButton.stories.tsx
@@ -15,6 +15,12 @@ export default {
         options: ['small', 'medium', 'large'],
       },
     },
+    description: {
+      control: {
+        type: 'text'
+      },
+      description: "Optional description text that will be subordinate to the label if present."
+    },
   },
 } as Meta;
 

--- a/packages/button-theme/stories/RadioButton.stories.tsx
+++ b/packages/button-theme/stories/RadioButton.stories.tsx
@@ -17,9 +17,9 @@ export default {
     },
     description: {
       control: {
-        type: 'text'
+        type: 'text',
       },
-      description: "Optional description text that will be subordinate to the label if present."
+      description: 'Optional description text that will be subordinate to the label if present.',
     },
   },
 } as Meta;

--- a/packages/component-library/src/Checkbox.tsx
+++ b/packages/component-library/src/Checkbox.tsx
@@ -6,6 +6,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   value?: string;
   className?: string;
   style?: object;
@@ -22,6 +23,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-checkbox';
 const LABEL_CLASS = 'pg-checkbox-label';
+const DESCRIPTION_CLASS = 'pg-checkbox-description';
 const INPUT_CLASS = 'pg-checkbox-input';
 const CHECKMARK_CLASS = 'checkmark';
 
@@ -32,14 +34,15 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const Scheckbox = styleBuilder('input', 'input');
   const Scheckmark = styleBuilder('span', 'checkmark');
 
   const bootstrap = createBootstrap(processedStyle, 'checkbox');
 
   const Checkbox = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, checkmarkStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, checkmarkStyle, ...others } = rest;
 
     return (
       <Scontainer {...styleProps} style={style} className={cx(CONTAINER_CLASS, className)}>
@@ -56,6 +59,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Scheckmark {...styleProps} style={checkmarkStyle} className={CHECKMARK_CLASS} />
           {label}
         </Slabel>
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
+        )}
       </Scontainer>
     );
   };

--- a/packages/component-library/src/DatePicker.tsx
+++ b/packages/component-library/src/DatePicker.tsx
@@ -6,6 +6,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   value?: string;
   disabled?: boolean;
   className?: string;
@@ -23,6 +24,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-datepicker';
 const LABEL_CLASS = 'pg-datepicker-label';
+const DESCRIPTION_CLASS = 'pg-datepicker-description';
 const INPUT_CLASS = 'pg-datepicker-input';
 const WRAPPER_CLASS = 'pg-datepicker-wrapper';
 
@@ -33,14 +35,15 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const Swapper = config.includeWrapper ? styleBuilder(as.wrapper || 'div', 'wrapper') : null;
   const Sinput = styleBuilder('input', 'input');
 
   const bootstrap = createBootstrap(processedStyle, 'datepicker');
 
   const BaseComponent = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, wrapperStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, wrapperStyle, ...others } = rest;
 
     const input = (
       <Sinput
@@ -60,6 +63,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Slabel htmlFor={id} {...styleProps} style={labelStyle} className={LABEL_CLASS}>
             {label}
           </Slabel>
+        )}
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
         )}
         {Swapper ? (
           <Swapper {...styleProps} style={wrapperStyle} className={WRAPPER_CLASS}>

--- a/packages/component-library/src/FilePicker.tsx
+++ b/packages/component-library/src/FilePicker.tsx
@@ -7,6 +7,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   value?: string;
   disabled?: boolean;
   className?: string;
@@ -24,6 +25,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-filepicker';
 const LABEL_CLASS = 'pg-filepicker-label';
+const DESCRIPTION_CLASS = 'pg-filepicker-description';
 const INPUT_CLASS = 'pg-filepicker-input';
 const WRAPPER_CLASS = 'pg-filepicker-wrapper';
 
@@ -56,13 +58,14 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const Sinput = styleBuilder('input', 'input');
 
   const bootstrap = createBootstrap(processedStyle, 'filepicker');
 
   const FilePicker = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, children, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, role, wrapperStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, children, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, role, wrapperStyle, ...others } = rest;
 
     return (
       <Scontainer {...styleProps} style={style} className={cx(CONTAINER_CLASS, className)}>
@@ -70,6 +73,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Slabel htmlFor={id} {...styleProps} style={labelStyle} className={LABEL_CLASS}>
             {label}
           </Slabel>
+        )}
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
         )}
         {children ? (
           <InputWrapper

--- a/packages/component-library/src/Input.tsx
+++ b/packages/component-library/src/Input.tsx
@@ -6,6 +6,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   type?: 'email' | 'number' | 'password' | 'tel' | 'text' | 'url';
   value?: string;
   disabled?: boolean;
@@ -24,6 +25,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-input';
 const LABEL_CLASS = 'pg-input-label';
+const DESCRIPTION_CLASS = 'pg-input-description';
 const INPUT_CLASS = 'pg-input-input';
 const WRAPPER_CLASS = 'pg-input-wrapper';
 
@@ -34,14 +36,15 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const Swapper = config.includeWrapper ? styleBuilder(as.wrapper || 'div', 'wrapper') : null;
   const Sinput = styleBuilder('input', 'input');
 
   const bootstrap = createBootstrap(processedStyle, 'input');
 
   const Input = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, wrapperStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, wrapperStyle, ...others } = rest;
 
     const input = (
       <Sinput aria-label={ariaLabel} {...others} id={id} name={name} style={inputStyle} className={INPUT_CLASS} />
@@ -53,6 +56,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Slabel htmlFor={id} {...styleProps} style={labelStyle} className={LABEL_CLASS}>
             {label}
           </Slabel>
+        )}
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
         )}
         {Swapper ? (
           <Swapper {...styleProps} style={wrapperStyle} className={WRAPPER_CLASS}>

--- a/packages/component-library/src/RadioButton.tsx
+++ b/packages/component-library/src/RadioButton.tsx
@@ -6,6 +6,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   value?: string;
   disabled?: boolean;
   className?: string;
@@ -22,6 +23,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-radio';
 const LABEL_CLASS = 'pg-radio-label';
+const DESCRIPTION_CLASS = 'pg-radio-description';
 const INPUT_CLASS = 'pg-radio-input';
 const DOT_CLASS = 'dot';
 
@@ -32,14 +34,15 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const SradioButton = styleBuilder('input', 'input');
   const Sdot = styleBuilder('span', 'dot');
 
   const bootstrap = createBootstrap(processedStyle, 'radio');
 
   const RadioButton = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, dotStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, dotStyle, ...others } = rest;
 
     return (
       <Scontainer {...styleProps} style={style} className={cx(CONTAINER_CLASS, className)}>
@@ -56,6 +59,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Sdot {...styleProps} style={dotStyle} className={DOT_CLASS} />
           {label}
         </Slabel>
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
+        )}
       </Scontainer>
     );
   };

--- a/packages/component-library/src/Select.tsx
+++ b/packages/component-library/src/Select.tsx
@@ -6,6 +6,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   value?: string;
   disabled?: boolean;
   children?: React.ReactNode;
@@ -24,6 +25,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-select';
 const LABEL_CLASS = 'pg-select-label';
+const DESCRIPTION_CLASS = 'pg-select-description';
 const INPUT_CLASS = 'pg-select-input';
 const WRAPPER_CLASS = 'pg-select-wrapper';
 
@@ -34,14 +36,15 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const Swapper = config.includeWrapper ? styleBuilder(as.wrapper || 'div', 'wrapper') : null;
   const Sselect = styleBuilder('select', 'input');
 
   const bootstrap = createBootstrap(processedStyle, 'select');
 
   const BaseComponent = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, children, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, wrapperStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, children, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, wrapperStyle, ...others } = rest;
 
     const input = (
       <Sselect aria-label={ariaLabel} {...others} id={id} name={name} style={inputStyle} className={INPUT_CLASS}>
@@ -55,6 +58,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Slabel htmlFor={id} {...styleProps} style={labelStyle} className={LABEL_CLASS}>
             {label}
           </Slabel>
+        )}
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
         )}
         {Swapper ? (
           <Swapper {...styleProps} style={wrapperStyle} className={WRAPPER_CLASS}>

--- a/packages/component-library/src/Textarea.tsx
+++ b/packages/component-library/src/Textarea.tsx
@@ -6,6 +6,7 @@ export interface Props {
   id?: string;
   name?: string;
   label?: string;
+  description?: string;
   value?: string;
   disabled?: boolean;
   className?: string;
@@ -23,6 +24,7 @@ export interface StyleConfig {
 
 const CONTAINER_CLASS = 'pg-textarea';
 const LABEL_CLASS = 'pg-textarea-label';
+const DESCRIPTION_CLASS = 'pg-textarea-description';
 const INPUT_CLASS = 'pg-textarea-input';
 const WRAPPER_CLASS = 'pg-textarea-wrapper';
 
@@ -33,14 +35,15 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
   const as = config.as || {};
   const Scontainer = styleBuilder(as.container || 'div', 'container');
   const Slabel = styleBuilder('label', 'label');
+  const Sdescription = styleBuilder('label', 'description');
   const Swapper = config.includeWrapper ? styleBuilder(as.wrapper || 'div', 'wrapper') : null;
   const Stextarea = styleBuilder('textarea', 'input');
 
   const bootstrap = createBootstrap(processedStyle, 'textarea');
 
   const BaseComponent = (props: Props) => {
-    const { id, name, label, ariaLabel, styleProps, className, rest } = bootstrap(props);
-    const { style, labelStyle, inputStyle, wrapperStyle, ...others } = rest;
+    const { id, name, label, description, ariaLabel, styleProps, className, rest } = bootstrap(props);
+    const { style, labelStyle, descriptionStyle, inputStyle, wrapperStyle, ...others } = rest;
 
     const input = (
       <Stextarea aria-label={ariaLabel} {...others} id={id} name={name} style={inputStyle} className={INPUT_CLASS} />
@@ -52,6 +55,11 @@ export const applyTheme = (styles, config: BaseStyleConfig) => {
           <Slabel htmlFor={id} {...styleProps} style={labelStyle} className={LABEL_CLASS}>
             {label}
           </Slabel>
+        )}
+        {description && (
+          <Sdescription htmlFor={id} {...styleProps} style={descriptionStyle} className={DESCRIPTION_CLASS}>
+            {description}
+          </Sdescription>
         )}
         {Swapper ? (
           <Swapper {...styleProps} style={wrapperStyle} className={WRAPPER_CLASS}>

--- a/packages/component-library/src/helpers.ts
+++ b/packages/component-library/src/helpers.ts
@@ -124,7 +124,7 @@ export function createBootstrap(styles: any, type: string) {
 
   return function (props: any) {
     let { id, name } = props;
-    const { label, children, className, ...rest } = props;
+    const { label, description, children, className, ...rest } = props;
 
     if (!id) {
       id = generateId();
@@ -138,7 +138,7 @@ export function createBootstrap(styles: any, type: string) {
 
     const styleProps = pickBy(rest, (_, propName) => styleKeys.includes(propName));
 
-    return { id, name, label, ariaLabel, styleProps, children, className, rest };
+    return { id, name, label, description, ariaLabel, styleProps, children, className, rest };
   };
 }
 

--- a/packages/form-schema/src/widgetWrapper.tsx
+++ b/packages/form-schema/src/widgetWrapper.tsx
@@ -15,7 +15,7 @@ const Wrapper = (Component, inputType: string = '') => {
   const valueKey = getValue(inputType);
   return props => {
     const { value, onChange, label, schema, options, required, disabled } = props;
-    const { name = label, pattern, minLength, maxLength, id } = schema;
+    const { name = label, description, pattern, minLength, maxLength, id } = schema;
     const { enumOptions = [] } = options;
     const formProps = {
       onChange: e => {
@@ -27,6 +27,7 @@ const Wrapper = (Component, inputType: string = '') => {
       },
       label,
       name,
+      description,
       maxLength,
       id,
       required,


### PR DESCRIPTION
# Proposed Changes
- form-schema passes through [rjsf's](https://react-jsonschema-form.readthedocs.io/en/v1.8.1/) optional `description` prop for use by form input components in component-library
- theme styling enabled for description labels
- description controls added to Storybook

Related to #359

## Needs work:
- ~[ ] HTML-only case does not yet render description labels (Storybook problem only)~
- [ ] styling across the different input components (esp. in the Button theme)
- [ ] double-check accessibility good practice on description labels