### PR TITLE
512 callout base component

### DIFF
--- a/packages/component-library/__tests__/Callout.test.tsx
+++ b/packages/component-library/__tests__/Callout.test.tsx
@@ -1,0 +1,34 @@
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import Callout from '../src/Callout';
+import 'regenerator-runtime/runtime';
+
+expect.extend(toHaveNoViolations);
+
+describe('Callout', () => {
+  it('Should have no accessibility violations', async () => {
+    const { container } = render(<Callout />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Should pass through end-user props', () => {
+    const handleClick = jest.fn();
+    render(<Callout onClick={handleClick} id="test" />);
+    const callout = document.getElementById('test');
+    fireEvent.click(callout);
+
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('Should render its children', () => {
+    const { getByText } = render(
+      <Callout>
+        <p>test text</p>
+      </Callout>
+    );
+    getByText('test text');
+  });
+});

--- a/packages/component-library/src/Callout.tsx
+++ b/packages/component-library/src/Callout.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import cx from 'clsx';
+import { processStyle, createStyleBuilder, createBootstrap, StyleConfig as BaseStyleConfig } from './helpers';
+
+export interface Props {
+  id?: string;
+  children?: React.ReactNode;
+  className?: string;
+  style?: object;
+  [key: string]: any;
+}
+
+const CONTAINER_CLASS = 'pg-callout';
+
+export interface StyleConfig {
+  defaultProps?: object;
+  staticProps?: string[];
+  breakProps?: string[];
+  as?: object;
+}
+
+export const applyTheme = (styles, config: BaseStyleConfig, childStyles = {}) => {
+  const processedStyle = processStyle(styles);
+  const processedChildStyle = processStyle(childStyles);
+  const styleBuilder = createStyleBuilder(processedStyle, config, processedChildStyle);
+
+  const as = config.as || {};
+  const Scontainer = styleBuilder(as.container || 'aside', 'container');
+
+  const bootstrap = createBootstrap(processedStyle, 'callout');
+
+  const BaseComponent = (props: Props) => {
+    const { id, name, label, ariaLabel, styleProps, children, className, rest } = bootstrap(props);
+    const { closable, ...others } = rest;
+
+    const checkboxId = `${id}-toggle`;
+
+    return (
+      <Scontainer {...styleProps} {...others} className={cx(CONTAINER_CLASS, className)}>
+        {children}
+      </Scontainer>
+    );
+  };
+
+  return BaseComponent;
+};
+
+const Callout = applyTheme({}, {}, {});
+
+export default Callout;


### PR DESCRIPTION
Fixes #512 

## Proposed Changes

- create the Callout base component (based-ish on the Notification component, which is what the bcgov Callout component uses as a base)
- test the Callout base component (based on the bcgov Callout tests)
- Note: we'll have to do a release of the `component-library` before we can change the import statements in the themes
