### PR TITLE
515 base link component

### DIFF
--- a/packages/component-library/__tests__/Link.test.tsx
+++ b/packages/component-library/__tests__/Link.test.tsx
@@ -1,0 +1,26 @@
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import Link from '../src/Link';
+import '@testing-library/jest-dom/extend-expect';
+import 'regenerator-runtime/runtime';
+import { changeSelectorToObject } from '../../bcgov-theme/utils/test-helpers';
+
+expect.extend(toHaveNoViolations);
+
+describe('Link', () => {
+  it('Should have no accessibility violations', async () => {
+    const { container } = render(<Link href="#link" />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('Should pass through end-user props', () => {
+    const handleClick = jest.fn();
+    render(<Link href="#link" onClick={handleClick} id="test" />);
+    const link = document.getElementById('test');
+    fireEvent.click(link);
+    expect(handleClick).toHaveBeenCalled();
+  });
+});

--- a/packages/component-library/__tests__/Link.test.tsx
+++ b/packages/component-library/__tests__/Link.test.tsx
@@ -10,15 +10,28 @@ expect.extend(toHaveNoViolations);
 
 describe('Link', () => {
   it('Should have no accessibility violations', async () => {
-    const { container } = render(<Link href="#link" />);
+    const { container } = render(<Link href="#link">some text</Link>);
     const results = await axe(container);
 
     expect(results).toHaveNoViolations();
   });
 
+  it('Should render its children', async () => {
+    const { container } = render(
+      <Link href="#link">
+        <p>test</p>
+      </Link>
+    );
+    expect(container.textContent).toMatch('test');
+  });
+
   it('Should pass through end-user props', () => {
     const handleClick = jest.fn();
-    render(<Link href="#link" onClick={handleClick} id="test" />);
+    render(
+      <Link href="#link" onClick={handleClick} id="test">
+        some text
+      </Link>
+    );
     const link = document.getElementById('test');
     fireEvent.click(link);
     expect(handleClick).toHaveBeenCalled();

--- a/packages/component-library/src/Link.tsx
+++ b/packages/component-library/src/Link.tsx
@@ -5,8 +5,9 @@ import { processStyle, createStyleBuilder, createBootstrap, StyleConfig as BaseS
 export interface Props {
   id?: string;
   className?: string;
+  children: React.ReactNode;
   style?: object;
-  href?: string;
+  href: string;
   [key: string]: any;
 }
 
@@ -21,9 +22,9 @@ const LINK_CLASS = 'pg-link';
 export const applyTheme = (styles, config: BaseStyleConfig) => {
   const processedStyle = processStyle(styles);
   const styleBuilder = createStyleBuilder(processedStyle, config);
-  const Slink = styleBuilder('link', 'link');
+  const Slink = styleBuilder('a', 'a');
 
-  const bootstrap = createBootstrap(processedStyle, 'link');
+  const bootstrap = createBootstrap(processedStyle, 'a');
 
   const Link = (props: Props) => {
     const { id, name, label, ariaLabel, styleProps, children, className, rest } = bootstrap(props);

--- a/packages/component-library/src/Link.tsx
+++ b/packages/component-library/src/Link.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import cx from 'clsx';
+import { processStyle, createStyleBuilder, createBootstrap, StyleConfig as BaseStyleConfig } from './helpers';
+
+export interface Props {
+  id?: string;
+  className?: string;
+  style?: object;
+  href?: string;
+  [key: string]: any;
+}
+
+export interface StyleConfig {
+  defaultProps?: object;
+  staticProps?: string[];
+  breakProps?: string[];
+}
+
+const LINK_CLASS = 'pg-link';
+
+export const applyTheme = (styles, config: BaseStyleConfig) => {
+  const processedStyle = processStyle(styles);
+  const styleBuilder = createStyleBuilder(processedStyle, config);
+  const Slink = styleBuilder('link', 'link');
+
+  const bootstrap = createBootstrap(processedStyle, 'link');
+
+  const Link = (props: Props) => {
+    const { id, name, label, ariaLabel, styleProps, children, className, rest } = bootstrap(props);
+
+    return (
+      <Slink {...rest} id={id} className={cx(LINK_CLASS, className)}>
+        {children}
+      </Slink>
+    );
+  };
+
+  return Link;
+};
+
+const Link = applyTheme({}, {});
+
+export default Link;


### PR DESCRIPTION
Fixes #515 

Note: Usually when a base component doesn't exist, the bcgov theme imports the `Notification` one and repurposes it. In this case, the bcgov `Link` doesn't import anything, so I don't have an example of what the base component should include.
