### PR TITLE
497 button hero image

### DIFF
--- a/packages/button-theme/__tests__/HeroImage.test.tsx
+++ b/packages/button-theme/__tests__/HeroImage.test.tsx
@@ -1,0 +1,16 @@
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { render } from '@testing-library/react';
+import React from 'react';
+import HeroImage from '../src/HeroImage';
+import 'regenerator-runtime/runtime';
+
+expect.extend(toHaveNoViolations);
+
+describe('HeroImage', () => {
+  it('Should have no accessibility violations', async () => {
+    const { container } = render(<HeroImage />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/packages/button-theme/src/HeroImage.tsx
+++ b/packages/button-theme/src/HeroImage.tsx
@@ -2,12 +2,30 @@ import React from 'react';
 import { applyTheme, StyleConfig } from '@button-inc/component-library/HeroImage';
 import styles from './styles';
 
+const heroImageStyles = {
+  ...styles,
+  shared: {
+    container: `
+      padding: 2rem 4rem;
+    `,
+    innercontainer: `
+      background: rgba(36, 118, 237, 0.8);
+      padding: 1rem 2rem;
+      color: #fff;
+
+      & a {
+        color: #fff;
+      }
+    `,
+  },
+};
+
 const config: StyleConfig = {
   defaultProps: {},
   staticProps: [],
 };
 
-export const BaseHeroImage = applyTheme(styles, config);
+export const BaseHeroImage = applyTheme(heroImageStyles, config);
 
 export default function HeroImage(props: any) {
   const { children, ...rest } = props;

--- a/packages/button-theme/src/HeroImage.tsx
+++ b/packages/button-theme/src/HeroImage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { applyTheme, StyleConfig } from '@button-inc/component-library/HeroImage';
+import styles from './styles';
+
+const config: StyleConfig = {
+  defaultProps: {},
+  staticProps: [],
+};
+
+export const BaseHeroImage = applyTheme(styles, config);
+
+export default function HeroImage(props: any) {
+  const { children, ...rest } = props;
+
+  return <BaseHeroImage {...rest}>{children}</BaseHeroImage>;
+}

--- a/packages/button-theme/stories/HeroImage.stories.tsx
+++ b/packages/button-theme/stories/HeroImage.stories.tsx
@@ -29,7 +29,7 @@ const HTMLTemplate: Story = args => (
   </HtmlOnlyWrapper>
 );
 
-const bgImage = 'https://picsum.photos/seed/button-inc/1000/100?blur';
+const bgImage = 'https://picsum.photos/seed/buttoninc/1000/100?blur';
 
 export const Default = Template.bind({});
 Default.args = {

--- a/packages/button-theme/stories/HeroImage.stories.tsx
+++ b/packages/button-theme/stories/HeroImage.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react/types-6-0';
+import HeroImage from '../src/HeroImage';
+import { HtmlOnlyWrapper } from '../../../stories/helpers';
+
+export default {
+  title: 'HeroImage',
+  component: HeroImage,
+  argTypes: {
+    url: {
+      description: 'The url of the background image',
+    },
+  },
+} as Meta;
+
+const Template: Story = args => (
+  <HeroImage {...args}>
+    <h1>Component child header</h1>
+    <p>Component child content</p>
+  </HeroImage>
+);
+
+const HTMLTemplate: Story = args => (
+  <HtmlOnlyWrapper>
+    <HeroImage {...args}>
+      <h1>Component child header</h1>
+      <p>Component child content</p>
+    </HeroImage>
+  </HtmlOnlyWrapper>
+);
+
+const bgImage = 'https://picsum.photos/seed/button-inc/1000/100?blur';
+
+export const Default = Template.bind({});
+Default.args = {
+  url: bgImage,
+};
+
+export const HTML = HTMLTemplate.bind({});


### PR DESCRIPTION
Fixes #497 

## Proposed Changes

- Adds Button themed `HeroImage `component derived from base components.

### Learnings

I got delayed for a bit due to the test erroring (_not_ failing). The error was something along the lines of `Jest encountered an unexpected token`. This was due to the module being imported into `button-theme/.../HeroImage.tsx` as `esm` rather than directly. ✔️  `import { applyTheme, StyleConfig } from '@button-inc/component-library/HeroImage';` vs ❌  `import { applyTheme, StyleConfig } from '@button-inc/component-library/esm/HeroImage';` Moral of the story: don't be like me, double check your auto-imports!