### PR TITLE
chore: create PR name linter github action

### DIFF
--- a/.github/workflows/pr-name.yml
+++ b/.github/workflows/pr-name.yml
@@ -1,0 +1,13 @@
+name: pr-name-linter
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: yarn add @commitlint/config-conventional -W
+      - uses: JulienKode/pull-request-name-linter-action@v0.5.0

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'], rules: { 'scope-case': [2, 'always', 'upper-case'] } };


### PR DESCRIPTION
Fixes #488 

Here's an example of it failing when the PR name fails the linter: https://github.com/button-inc/service-development-toolkit/actions/runs/3341101024
