### PR TITLE
fix: resolve issue with button variant detection

### DIFF
--- a/packages/bcgov-theme/stories/button/Button.stories.tsx
+++ b/packages/bcgov-theme/stories/button/Button.stories.tsx
@@ -10,17 +10,21 @@ export default {
   argTypes,
 } as Meta;
 
-export const Template: Story = args => (
-  <>
-    {args.variant.endsWith('-inverse') ? (
-      <div style={{ backgroundColor: '#003366', padding: '15px' }}>
+export const Template: Story = args => {
+  const variant = args.variant || ''; // Default to an empty string if args.variant is undefined
+
+  return (
+    <>
+      {variant.endsWith('-inverse') ? (
+        <div style={{ backgroundColor: '#003366', padding: '15px' }}>
+          <Button {...args}>Click Me!</Button>
+        </div>
+      ) : (
         <Button {...args}>Click Me!</Button>
-      </div>
-    ) : (
-      <Button {...args}>Click Me!</Button>
-    )}
-  </>
-);
+      )}
+    </>
+  );
+};
 
 const HTMLTemplate: Story = args => (
   <>


### PR DESCRIPTION
📝 Problem: #584 
The previous code did not handle the case where 'args.variant' was undefined, leading to a 'Cannot read properties of undefined' error.

🛠️ Solution:
Added a check to ensure 'args.variant' is defined before using it in the conditional logic. If 'args.variant' is undefined, it defaults to an empty string, preventing the error and allowing proper detection of the variant.

🚀 Impact:
This fix ensures that the button variant detection works correctly, providing a smoother user experience and preventing potential errors.

